### PR TITLE
Fix `PORT` type to Number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ async function main() {
       }
     );
   }
-  const PORT = process.env.PORT || 4000;
+  const PORT = Number(process.env.PORT) || 4000;
   const HOST = process.env.HOST || "localhost";
   console.log(`🎉 Started chatgpt success!`);
   app.listen(PORT, HOST, () => {


### PR DESCRIPTION
> fix #20

The `port` must be number, but the `process.env.PORT` is a string.
```ts
// https://github.com/implydata/express-serve-static-core/blob/0b54183d98b43aeb0a7546070e5d4b10ef6bb0c4/express-serve-static-core.d.ts#L1025
listen(port: number, hostname: string, callback?: () => void): http.Server;
``` 